### PR TITLE
Fix version of Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:12.04.5
 
 RUN echo 'deb http://archive.ubuntu.com/ubuntu precise multiverse' >> /etc/apt/sources.list
 RUN apt-get update


### PR DESCRIPTION
Use fixed version of Ubuntu Precise 12.04.5, otherwise the build will be unable to complete. Latest Ubuntu does not support all the installs, but setting it to the specific version allows it to build successfully.