### PR TITLE
Update Ubuntu version to 12.04.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Dockerfile building an image with OpenCV 2.4.8 on top of Ubuntu:latest
+Dockerfile building an image with OpenCV 2.4.8 on top of Ubuntu:12.04.5
 
 [Docker Index](https://index.docker.io/u/rtux/ubuntu-opencv/)


### PR DESCRIPTION
Minor change again. Note the old Ubuntu that works with the installation method for OpenCV 2.4.8.